### PR TITLE
Add ArchieML 0.5.0 support with backward compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "google-drive-sync",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "google-drive-sync",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.478.0",
         "archieml": "^0.4.2",
+        "archieml-new": "npm:archieml@^0.5.0",
         "bluebird": "^3.7.2",
         "daemon": "^1.1.0",
         "debug": "^4.1.1",
@@ -3472,6 +3473,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/archieml/-/archieml-0.4.2.tgz",
       "integrity": "sha512-p8sXQqg9Wmud25PctpEOvrxqMGML5dZ7jiuv5QgJkZjjH8TrwxUqXVXBhxK1oTG7F246FwGM4r2RaAsevzbxgg=="
+    },
+    "node_modules/archieml-new": {
+      "name": "archieml",
+      "version": "0.5.0",
+      "resolved": "https://artifactory.schibsted.io/artifactory/api/npm/npm-virtual/archieml/-/archieml-0.5.0.tgz",
+      "integrity": "sha512-HhL+z+8toD2M9b+TijMR/3fmbs6dhWcATBstpQFTCqU4iyqDENznwZ4JRN0w3EkBbUL34jOv3PJK5/45VF9hJA=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.478.0",
     "archieml": "^0.4.2",
+    "archieml-new": "npm:archieml@^0.5.0",
     "bluebird": "^3.7.2",
     "daemon": "^1.1.0",
     "debug": "^4.1.1",

--- a/src/archie-converter.js
+++ b/src/archie-converter.js
@@ -1,4 +1,5 @@
 import archieml from 'archieml';
+import archiemlNew from 'archieml-new';
 import htmlparser from 'htmlparser2';
 import urlm from 'url';
 import _ from 'underscore';
@@ -12,8 +13,15 @@ export default class ArchieConverter {
     static convert(html, options = {}) {
         return this.parseHtml(html, options).then((aml) => {
             try {
+                // Fix missing newlines before ArchieML directives for version 0.5.0
+                // This ensures directives like [array] and :skip are on their own lines
+                if (options.useNewVersion) {
+                    aml = aml.replace(/([^\n])(\[[\w\.\+\-]+\]|:\w+)/g, '$1\n$2');
+                }
+                
+                const archiemlLib = options.useNewVersion ? archiemlNew : archieml;
                 return {
-                    result: archieml.load(aml),
+                    result: archiemlLib.load(aml),
                     aml: aml,
                 };
             } catch (err) {
@@ -25,8 +33,9 @@ export default class ArchieConverter {
         });
     }
 
-    static convertText(aml) {
-        return Promise.resolve({ result: archieml.load(aml) });
+    static convertText(aml, options = {}) {
+        const archiemlLib = options.useNewVersion ? archiemlNew : archieml;
+        return Promise.resolve({ result: archiemlLib.load(aml) });
     }
 
     static parseHtml(str, options = {}) {

--- a/src/convert-cli.js
+++ b/src/convert-cli.js
@@ -13,12 +13,19 @@ const argv = yargs
         choices: ['xlsx', 'html', 'archieml'],
         required: true,
     })
+    .option('archieml-version', {
+        alias: 'v',
+        describe: 'ArchieML version to use (only for html/archieml types)',
+        choices: ['0.4', '0.5'],
+        default: '0.4',
+    })
     .demand(1)
     .help('help').argv;
 
 const [file] = argv._;
 
 const inputPath = file === '-' ? '/dev/stdin' : file;
+const useNewVersion = argv.archiemlVersion === '0.5';
 
 switch (argv.type) {
     case 'xlsx':
@@ -28,12 +35,12 @@ switch (argv.type) {
         break;
     case 'html':
         fs.readFile(inputPath, 'utf-8')
-            .then((data) => ArchieConverter.convert(data))
+            .then((data) => ArchieConverter.convert(data, { useNewVersion }))
             .then((r) => printJson(r.result));
         break;
     case 'archieml':
         fs.readFile(inputPath, 'utf-8')
-            .then((data) => ArchieConverter.convertText(data))
+            .then((data) => ArchieConverter.convertText(data, { useNewVersion }))
             .then((r) => printJson(r.result));
         break;
     default:

--- a/src/syncer.js
+++ b/src/syncer.js
@@ -140,6 +140,11 @@ export default class Syncer {
                         mimeType: 'application/json',
                     },
                     {
+                        fileName: `${file.id}.v5.json`,
+                        data: results.plainV5,
+                        mimeType: 'application/json',
+                    },
+                    {
                         fileName: `${file.id}.aml`,
                         data: results.aml,
                         mimeType: 'text/plain',
@@ -228,11 +233,15 @@ export default class Syncer {
                     styled: ArchieConverter.convert(html, {
                         preserve_styles: ['bold', 'italic', 'underline'],
                     }),
+                    plainV5: ArchieConverter.convert(html, {
+                        useNewVersion: true,
+                    }),
                 })
             )
-            .then(({ plain, styled, html }) => ({
+            .then(({ plain, styled, plainV5, html }) => ({
                 plain: plain.result,
                 styled: styled.result,
+                plainV5: plainV5.result,
                 aml: plain.aml,
                 html,
             }));


### PR DESCRIPTION
- Added archieml-new package as npm alias to archieml@^0.5.0
- Modified ArchieConverter to support both 0.4.2 and 0.5.0 versions via useNewVersion option
- Added bugfix for 0.5.0 to ensure ArchieML directives start on new lines (fixes array parsing)
- Updated Syncer to generate both .json (0.4.2) and .v5.json (0.5.0) files
- Enhanced convert-cli with --archieml-version flag for local testing
- Preserved legacy 0.4.2 behavior completely unchanged

The HTML parser sometimes concatenates ArchieML directives without newlines, causing arrays to be parsed incorrectly in 0.5.0. This fix only applies to 0.5.0 to maintain exact backward compatibility with existing 0.4.2 behavior.